### PR TITLE
feat(image): add Generate with Reference operation

### DIFF
--- a/nodes/Pollinations/Pollinations.node.ts
+++ b/nodes/Pollinations/Pollinations.node.ts
@@ -5,6 +5,7 @@ import {
 	INodePropertyOptions,
 	INodeType,
 	INodeTypeDescription,
+	NodeOperationError,
 } from 'n8n-workflow';
 
 export class Pollinations implements INodeType {
@@ -40,6 +41,12 @@ export class Pollinations implements INodeType {
 						value: 'generateImage',
 						description: 'Generate an image from a text prompt',
 						action: 'Generate an image from a text prompt',
+					},
+					{
+						name: 'Generate with Reference',
+						value: 'generateImageWithReference',
+						description: 'Generate an image using a reference image',
+						action: 'Generate an image using a reference image',
 					},
 					{
 						name: 'Generate Text',
@@ -98,6 +105,125 @@ export class Pollinations implements INodeType {
 				displayOptions: {
 					show: {
 						operation: ['generateImage'],
+					},
+				},
+				options: [
+					{
+						displayName: 'Width',
+						name: 'width',
+						type: 'number',
+						default: 1024,
+						description: 'Width of the generated image in pixels',
+						typeOptions: {
+							minValue: 64,
+							maxValue: 2048,
+						},
+					},
+					{
+						displayName: 'Height',
+						name: 'height',
+						type: 'number',
+						default: 1024,
+						description: 'Height of the generated image in pixels',
+						typeOptions: {
+							minValue: 64,
+							maxValue: 2048,
+						},
+					},
+					{
+						displayName: 'Seed',
+						name: 'seed',
+						type: 'number',
+						default: 0,
+						description: 'Seed for reproducible generation. Use 0 for random.',
+					},
+					{
+						displayName: 'No Logo',
+						name: 'nologo',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to remove the Pollinations watermark',
+					},
+					{
+						displayName: 'Enhance Prompt',
+						name: 'enhance',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to automatically enhance the prompt for better results',
+					},
+					{
+						displayName: 'Safe Mode',
+						name: 'safe',
+						type: 'boolean',
+						default: false,
+						description: 'Whether to enable content safety filter',
+					},
+				],
+			},
+
+			// ==================== GENERATE IMAGE WITH REFERENCE ====================
+
+			// Prompt (Reference)
+			{
+				displayName: 'Prompt',
+				name: 'referencePrompt',
+				type: 'string',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: ['generateImageWithReference'],
+					},
+				},
+				description: 'The text prompt describing how to transform or use the reference image',
+				typeOptions: {
+					rows: 4,
+				},
+			},
+
+			// Reference Image URL (Required)
+			{
+				displayName: 'Reference Image URL',
+				name: 'referenceImage',
+				type: 'string',
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: ['generateImageWithReference'],
+					},
+				},
+				placeholder: 'https://example.com/image.jpg',
+				description: 'URL of the reference image. Must be publicly accessible.',
+			},
+
+			// Model (Reference) - Dynamic loading with image input support
+			{
+				displayName: 'Model',
+				name: 'referenceModel',
+				type: 'options',
+				default: 'kontext',
+				displayOptions: {
+					show: {
+						operation: ['generateImageWithReference'],
+					},
+				},
+				typeOptions: {
+					loadOptionsMethod: 'getImageModelsWithReferenceSupport',
+				},
+				description: 'The model to use. Only models supporting image input are shown.',
+			},
+
+			// Advanced Options (Reference)
+			{
+				displayName: 'Options',
+				name: 'referenceOptions',
+				type: 'collection',
+				placeholder: 'Add Option',
+				default: {},
+				displayOptions: {
+					show: {
+						operation: ['generateImageWithReference'],
 					},
 				},
 				options: [
@@ -399,6 +525,72 @@ export class Pollinations implements INodeType {
 					];
 				}
 			},
+
+			async getImageModelsWithReferenceSupport(
+				this: ILoadOptionsFunctions,
+			): Promise<INodePropertyOptions[]> {
+				try {
+					const credentials = await this.getCredentials('pollinationsApi');
+					const apiKey = credentials.apiKey as string;
+
+					const response = await this.helpers.httpRequest({
+						method: 'GET',
+						url: 'https://gen.pollinations.ai/image/models',
+						headers: {
+							Authorization: `Bearer ${apiKey}`,
+						},
+					});
+
+					if (Array.isArray(response)) {
+						// Filter only image models that support image input (for reference/transformation)
+						const imageModels = response.filter(
+							(model: { output_modalities?: string[]; input_modalities?: string[] }) =>
+								model.output_modalities?.includes('image') &&
+								!model.output_modalities?.includes('video') &&
+								model.input_modalities?.includes('image'),
+						);
+
+						return imageModels.map(
+							(model: {
+								name: string;
+								description: string;
+								pricing?: { completionImageTokens?: number };
+							}) => {
+								let displayName = model.description || model.name;
+
+								// Add pricing info if available
+								if (model.pricing?.completionImageTokens) {
+									const imagesPerPollen = Math.floor(1 / model.pricing.completionImageTokens);
+									displayName += ` (~${imagesPerPollen.toLocaleString()} img/$)`;
+								}
+
+								return {
+									name: displayName,
+									value: model.name,
+								};
+							},
+						);
+					}
+
+					// Fallback if API fails
+					return [
+						{ name: 'FLUX.1 Kontext', value: 'kontext' },
+						{ name: 'NanoBanana', value: 'nanobanana' },
+						{ name: 'NanoBanana Pro', value: 'nanobanana-pro' },
+						{ name: 'Seedream 4.0', value: 'seedream' },
+						{ name: 'GPT Image 1 Mini', value: 'gptimage' },
+					];
+				} catch {
+					// Fallback if API fails
+					return [
+						{ name: 'FLUX.1 Kontext', value: 'kontext' },
+						{ name: 'NanoBanana', value: 'nanobanana' },
+						{ name: 'NanoBanana Pro', value: 'nanobanana-pro' },
+						{ name: 'Seedream 4.0', value: 'seedream' },
+						{ name: 'GPT Image 1 Mini', value: 'gptimage' },
+					];
+				}
+			},
 		},
 	};
 
@@ -597,6 +789,120 @@ export class Pollinations implements INodeType {
 
 				returnData.push({
 					json: metadata,
+				});
+			}
+
+			if (operation === 'generateImageWithReference') {
+				const prompt = this.getNodeParameter('referencePrompt', i) as string;
+				const referenceImage = this.getNodeParameter('referenceImage', i) as string;
+				const model = this.getNodeParameter('referenceModel', i) as string;
+				const options = this.getNodeParameter('referenceOptions', i, {}) as {
+					width?: number;
+					height?: number;
+					seed?: number;
+					nologo?: boolean;
+					enhance?: boolean;
+					safe?: boolean;
+				};
+
+				// Validate reference image URL
+				try {
+					new URL(referenceImage);
+				} catch {
+					throw new NodeOperationError(
+						this.getNode(),
+						`Invalid reference image URL: "${referenceImage}"`,
+						{ itemIndex: i },
+					);
+				}
+
+				// Get credentials
+				const credentials = await this.getCredentials('pollinationsApi');
+				const apiKey = credentials.apiKey as string;
+
+				// Build query parameters
+				const queryParams: Record<string, string> = {
+					model,
+					image: referenceImage,
+				};
+
+				if (options.width) {
+					queryParams.width = options.width.toString();
+				}
+				if (options.height) {
+					queryParams.height = options.height.toString();
+				}
+				if (options.seed) {
+					queryParams.seed = options.seed.toString();
+				}
+				if (options.nologo) {
+					queryParams.nologo = 'true';
+				}
+				if (options.enhance) {
+					queryParams.enhance = 'true';
+				}
+				if (options.safe) {
+					queryParams.safe = 'true';
+				}
+
+				// Build the URL
+				const baseUrl = 'https://gen.pollinations.ai/image';
+				const encodedPrompt = encodeURIComponent(prompt);
+				const queryString = new URLSearchParams(queryParams).toString();
+				const fullUrl = `${baseUrl}/${encodedPrompt}?${queryString}`;
+
+				// Record start time
+				const startTime = Date.now();
+
+				// Make the request with authentication
+				const response = await this.helpers.httpRequest({
+					method: 'GET',
+					url: fullUrl,
+					headers: {
+						Authorization: `Bearer ${apiKey}`,
+					},
+					encoding: 'arraybuffer',
+					returnFullResponse: true,
+				});
+
+				// Calculate duration
+				const duration = Date.now() - startTime;
+
+				// Prepare binary data
+				const binaryData = await this.helpers.prepareBinaryData(
+					Buffer.from(response.body as ArrayBuffer),
+					'image.png',
+					'image/png',
+				);
+
+				// Build metadata for debugging
+				const metadata = {
+					request: {
+						url: fullUrl,
+						prompt,
+						model,
+						referenceImage,
+						width: options.width || 1024,
+						height: options.height || 1024,
+						seed: options.seed || null,
+						nologo: options.nologo || false,
+						enhance: options.enhance || false,
+						safe: options.safe || false,
+					},
+					response: {
+						statusCode: response.statusCode,
+						contentType: response.headers?.['content-type'] || 'image/png',
+						contentLength: response.headers?.['content-length'] || null,
+						duration: `${duration}ms`,
+					},
+					timestamp: new Date().toISOString(),
+				};
+
+				returnData.push({
+					json: metadata,
+					binary: {
+						data: binaryData,
+					},
 				});
 			}
 		}


### PR DESCRIPTION
## Summary
- Add new "Generate with Reference" operation for image-to-image generation
- Implement dynamic model filtering to show only models supporting image input (`input_modalities: ["image"]`)
- Add `getImageModelsWithReferenceSupport` method that queries the API and filters compatible models

Closes #2 

## Test plan
- [x] Verify new operation appears in the operation dropdown
- [x] Verify "Reference Image URL" field is required and validates URLs
- [x] Verify model dropdown only shows compatible models (kontext, nanobanana, nanobanana-pro, seedream, gptimage, flux-klein)
- [x] Verify image generation works with a reference image URL
- [x] Verify response includes `referenceImage` in metadata